### PR TITLE
chore: reuse or pin local Actions + Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/.github/workflows/terraform-conftest.yml
+++ b/.github/workflows/terraform-conftest.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
 
       - name: Run Terraform Conftest
         id: conftest


### PR DESCRIPTION
## Summary
- Convert `validate-devschema` / custom markdown-lint to actionsforge reusables where they fit
- SHA-pin remaining floating marketplace actions
- Add Dependabot for `github-actions` when missing

## Test plan
- [ ] Required workflow checks pass